### PR TITLE
simplify aborting process

### DIFF
--- a/src/main/java/com/microfocus/lrc/core/ApiClient.kt
+++ b/src/main/java/com/microfocus/lrc/core/ApiClient.kt
@@ -80,6 +80,16 @@ class ApiClient internal constructor(
         return reqBuilder;
     }
 
+    private fun execute(reqBuilder: Request.Builder): Response {
+        try {
+            return this.getOkhttpClient().newCall(reqBuilder.build()).execute();
+        } catch (ex: UnknownHostException) {
+            throw IOException("Cannot resolve hostname: ${ex.message}, please check your configuration");
+        } catch (ex: SSLHandshakeException) {
+            throw IOException("Cannot access server, please check if you are behind a proxy server");
+        }
+    }
+
     fun get(
         apiPath: String,
         queryParams: Map<String, String>? = null,
@@ -97,14 +107,7 @@ class ApiClient internal constructor(
         }
 
         val reqBuilder = this.prepareRequestBuilder(urlBuilder.build(), contentType).get();
-
-        try {
-            return this.getOkhttpClient().newCall(reqBuilder.build()).execute();
-        } catch (ex: UnknownHostException) {
-            throw IOException("Cannot resolve hostname: ${ex.message}, please check your configuration");
-        } catch (ex: SSLHandshakeException) {
-            throw IOException("Cannot access server, please check if you are behind a proxy server");
-        }
+        return this.execute(reqBuilder);
     }
 
     fun post(apiPath: String, queryParams: Map<String, String>? = null, payload: JsonObject): Response {
@@ -113,16 +116,9 @@ class ApiClient internal constructor(
             queryParams.forEach { (k, v) -> run { urlBuilder.addQueryParameter(k, v); } }
         }
         val reqBuilder = this.prepareRequestBuilder(urlBuilder.build());
+        reqBuilder.post(payload.toString().toRequestBody(MEDIA_TYPE_JSON.toMediaType()));
 
-        reqBuilder.post(payload.toString().toRequestBody(MEDIA_TYPE_JSON));
-
-        try {
-            return this.getOkhttpClient().newCall(reqBuilder.build()).execute();
-        } catch (ex: UnknownHostException) {
-            throw IOException("Cannot resolve hostname: ${ex.message}, please check your configuration");
-        } catch (ex: SSLHandshakeException) {
-            throw IOException("Cannot access server, please check if you are behind a proxy server");
-        }
+        return this.execute(reqBuilder);
     }
 
     fun put(apiPath: String, queryParams: Map<String, String>? = null, payload: JsonObject): Response {
@@ -133,16 +129,9 @@ class ApiClient internal constructor(
         }
 
         val reqBuilder = this.prepareRequestBuilder(urlBuilder.build());
+        reqBuilder.put(payload.toString().toRequestBody(MEDIA_TYPE_JSON.toMediaType()));
 
-        reqBuilder.put(payload.toString().toRequestBody(MEDIA_TYPE_JSON));
-
-        try {
-            return this.getOkhttpClient().newCall(reqBuilder.build()).execute();
-        } catch (ex: UnknownHostException) {
-            throw IOException("Cannot resolve hostname: ${ex.message}, please check your configuration");
-        } catch (ex: SSLHandshakeException) {
-            throw IOException("Cannot access server, please check if you are behind a proxy server");
-        }
+        return this.execute(reqBuilder);
     }
 
     fun login() {

--- a/src/main/java/com/microfocus/lrc/core/ApiClient.kt
+++ b/src/main/java/com/microfocus/lrc/core/ApiClient.kt
@@ -116,7 +116,7 @@ class ApiClient internal constructor(
             queryParams.forEach { (k, v) -> run { urlBuilder.addQueryParameter(k, v); } }
         }
         val reqBuilder = this.prepareRequestBuilder(urlBuilder.build());
-        reqBuilder.post(payload.toString().toRequestBody(MEDIA_TYPE_JSON.toMediaType()));
+        reqBuilder.post(payload.toString().toRequestBody(MEDIA_TYPE_JSON));
 
         return this.execute(reqBuilder);
     }
@@ -129,7 +129,7 @@ class ApiClient internal constructor(
         }
 
         val reqBuilder = this.prepareRequestBuilder(urlBuilder.build());
-        reqBuilder.put(payload.toString().toRequestBody(MEDIA_TYPE_JSON.toMediaType()));
+        reqBuilder.put(payload.toString().toRequestBody(MEDIA_TYPE_JSON));
 
         return this.execute(reqBuilder);
     }

--- a/src/main/java/com/microfocus/lrc/core/entity/TestRunOptions.kt
+++ b/src/main/java/com/microfocus/lrc/core/entity/TestRunOptions.kt
@@ -16,6 +16,12 @@ import java.io.Serializable
 
 class TestRunOptions(
     val testId: Int,
-    val sendEmail: Boolean
+    val sendEmail: Boolean,
+    var skipLogin: Boolean,
+    var skipPdfReport: Boolean,
+    var isDebug: Boolean,
 ): Serializable {
+    constructor(testId: Int, sendEmail: Boolean) : this(
+        testId, sendEmail, false, false, false
+    )
 }

--- a/src/main/java/com/microfocus/lrc/core/entity/TrendingDataWrapper.java
+++ b/src/main/java/com/microfocus/lrc/core/entity/TrendingDataWrapper.java
@@ -219,11 +219,6 @@ public final class TrendingDataWrapper implements Serializable {
         public int getRunId() {
             return runId;
         }
-
-        private void setRunId(final int runId) {
-            this.runId = runId;
-        }
-
         public double getDuration() {
             return duration;
         }

--- a/src/main/java/com/microfocus/lrc/core/entity/TrendingDataWrapper.java
+++ b/src/main/java/com/microfocus/lrc/core/entity/TrendingDataWrapper.java
@@ -27,8 +27,9 @@ import java.util.List;
  * Will be persisted by Jenkins as a member field of StormTestReportBuildAction.
  */
 
-//#TODO: add [serialVersionUID](http://www.javapractices.com/topic/TopicAction.do?Id=45)
 public final class TrendingDataWrapper implements Serializable {
+
+    static final long serialVersionUID = 1L;
 
     private TrendingData trendingData;
     private TrendingData benchmark;

--- a/src/main/java/com/microfocus/lrc/core/service/ReportDownloader.kt
+++ b/src/main/java/com/microfocus/lrc/core/service/ReportDownloader.kt
@@ -149,18 +149,10 @@ class ReportDownloader(
     private fun genXmlFile(testRun: LoadTestRun) {
         val fileName = genFileName("xml", testRun);
         val content = XmlReport.write(
-            testRun.loadTest.id,
-            testRun.id,
-            testRun.loadTest.name,
-            testRun.detailedStatus,
-            testRun.status,
-            testRun.startTime,
-            testRun.endTime,
-            testRun.testRunCompletelyEnded(),
+            testRun,
             "${this.apiClient.getServerConfiguration().url}/run-overview/${testRun.id}/report/?TENANTID=${this.apiClient.getServerConfiguration().tenantId}&projectId=${this.apiClient.getServerConfiguration().projectId}",
             "${this.apiClient.getServerConfiguration().url}/run-overview/${testRun.id}/dashboard/?TENANTID=${this.apiClient.getServerConfiguration().tenantId}&projectId=${this.apiClient.getServerConfiguration().projectId}",
             null,
-            testRun.statusCode,
         );
         testRun.reports[fileName] = content;
     }

--- a/src/main/java/com/microfocus/lrc/jenkins/ConfigurationFactory.kt
+++ b/src/main/java/com/microfocus/lrc/jenkins/ConfigurationFactory.kt
@@ -18,7 +18,7 @@ import java.net.MalformedURLException
 import java.net.Proxy
 import java.net.URL
 
-class ProxyConfigurationFactory {
+class ConfigurationFactory {
     companion object {
         @JvmStatic
         fun createProxyConfiguration(

--- a/src/main/java/com/microfocus/lrc/jenkins/TestRunBuilder.java
+++ b/src/main/java/com/microfocus/lrc/jenkins/TestRunBuilder.java
@@ -44,7 +44,9 @@ import org.kohsuke.stapler.StaplerRequest;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public final class TestRunBuilder extends Builder implements SimpleBuildStep {
@@ -530,62 +532,34 @@ public final class TestRunBuilder extends Builder implements SimpleBuildStep {
         );
         serverConfiguration.setProxyConfiguration(proxyConfiguration);
 
-        JsonObject buildResult = new JsonObject();
-        buildResult.addProperty(Constants.PROJECTID, this.getProjectIdAtRunTime(run, launcher));
-        buildResult.addProperty(Constants.SENDEMAIL, this.isSendEmail());
-        String resultStr = buildResult.toString();
-        FilePath resultFile = workspace.child("build_result_" + run.getId());
         int testIdVal = Integer.parseInt(this.getTestIdAtRunTime(run, launcher));
-        TestRunOptions opt = new TestRunOptions(testIdVal, this.sendEmail);
         Map<String, String> envVarsObj = this.readConfigFromEnvVars(run, launcher);
+        TestRunOptions opt = new TestRunOptions(
+                testIdVal,
+                this.sendEmail,
+                Boolean.parseBoolean(envVarsObj.get(OptionInEnvVars.SRL_CLI_SKIP_LOGIN.name())),
+                Boolean.parseBoolean(envVarsObj.get(OptionInEnvVars.LRC_SKIP_PDF_REPORT.name())),
+                Boolean.parseBoolean(envVarsObj.get(OptionInEnvVars.LRC_DEBUG_LOG.name()))
+        );
 
         RunTestCallable callable = new RunTestCallable(
+                logger,
                 serverConfiguration,
-                listener,
-                resultStr,
-                resultFile,
-                opt,
-                envVarsObj
+                opt
         );
+
         LoadTestRun testRun = null;
-        String interruptionDone = null;
 
         try {
             VirtualChannel channel = launcher.getChannel();
             if (channel != null) {
                 testRun = channel.call(callable);
             }
-        } catch (IOException e) {
-            this.loggerProxy.info("[ERROR] " + e.getMessage());
         } catch (InterruptedException e) {
-            //#region this catch block will only be executed when the job runs on slave
-
-            this.loggerProxy.info("interruption occurred, waiting for execution ending.");
-            interruptionDone = Constants.UNKNOWN;
-            int elapsedWaiting = 0;
-            while (Constants.UNKNOWN.equals(interruptionDone) && elapsedWaiting < 1000 * 60 * 3) {
-                Thread.sleep(10000);
-                elapsedWaiting += 10000;
-                interruptionDone = EnvVars.getRemote(launcher.getChannel()).get(testIdVal + "_INTERRUPTION");
-                this.loggerProxy.info("still waiting for execution ending...");
-            }
-            testRun = checkInterruptionDone(run, testRun, resultFile, interruptionDone);
-            this.loggerProxy.debug(
-                    new StringBuilder()
-                            .append("interruption done: ").append(interruptionDone)
-                            .append(", test run restored: ").append(testRun == null ? "null" : testRun.getId())
-                            .toString()
-            );
-            //#endregion
-        }
-
-        if (
-                interruptionDone == null
-                        && EnvVars.getRemote(launcher.getChannel()).containsKey(testIdVal + "_INTERRUPTION")
-        ) {
-            //which means the InterruptedException is not caught(running on master)
-            interruptionDone = EnvVars.getRemote(launcher.getChannel()).get(testIdVal + "_INTERRUPTION");
-            testRun = checkInterruptionDone(run, testRun, resultFile, interruptionDone);
+            loggerProxy.info("Test run interrupted");
+            throw e;
+        } catch (Exception e) {
+            loggerProxy.error(e.getMessage());
         }
 
         if (testRun == null) {
@@ -594,15 +568,27 @@ public final class TestRunBuilder extends Builder implements SimpleBuildStep {
             return;
         }
 
-        testRun.getReports().forEach((fileName, content) -> {
+        List<String> fileNames = new ArrayList<>();
+        testRun.getReports().forEach((fileName, content) -> fileNames.add(fileName));
+
+        for (String fileName : fileNames) {
+            byte[] content = testRun.getReports().get(fileName);
             FilePath file = workspace.child(fileName);
             try (OutputStream out = file.write()) {
                 out.write(content);
                 this.loggerProxy.info("Report file " + file.getRemote() + " created.");
-            } catch (IOException | InterruptedException e) {
-                this.loggerProxy.error("Error during writing file " + fileName + ", " + e.getMessage());
+            } catch (IOException e) {
+                this.loggerProxy.error("Failed to create report file " + file.getRemote());
+                this.loggerProxy.error(e.getMessage());
             }
-        });
+        }
+
+        // remove reports data to write a smaller json
+        JsonObject buildResult = new JsonObject();
+        buildResult.addProperty("testOptions", new Gson().toJson(opt));
+        buildResult.addProperty("testRun", new Gson().toJson(testRun));
+
+        workspace.child(String.format("lrc_run_result_%s", run.getId())).write(buildResult.toString(), "UTF-8");
 
         if (testRun.getStatusEnum().isSuccess()) {
             run.setResult(Result.SUCCESS);
@@ -713,164 +699,46 @@ public final class TestRunBuilder extends Builder implements SimpleBuildStep {
         }
     }
 
-    private LoadTestRun checkInterruptionDone(
-            final Run<?, ?> run,
-            final LoadTestRun testRun,
-            final FilePath resultFile,
-            final String interruptionDone
-    ) throws InterruptedException {
-        LoadTestRun restored = testRun;
-        if (Constants.UNKNOWN.equals(interruptionDone)) {
-            this.loggerProxy.error("Jenkins job interruption handler failed, stop waiting.");
-            this.loggerProxy.info(
-                    "you may need to go to the LoadRunner Cloud website "
-                            + "to check if you need to stop the test manually."
-            );
-        } else {
-            restored = restoreTestRunFromFile(resultFile);
-            setJenkinsRunResult(run, interruptionDone);
-        }
-        return restored;
-    }
+    private static class RunTestCallable implements Callable<LoadTestRun, Exception> {
 
-    private LoadTestRun restoreTestRunFromFile(final FilePath resultFile) throws InterruptedException {
-        LoadTestRun testRun = null;
-        try {
-            String result = resultFile.readToString();
-            this.loggerProxy.info("execution ended gracefully");
-
-            JsonObject resultObj = new Gson().fromJson(result, JsonObject.class);
-            String testRunObj = resultObj.get(Constants.TESTRUN).getAsString();
-            testRun = new Gson().fromJson(testRunObj, LoadTestRun.class);
-        } catch (IOException | RuntimeException ex) {
-            this.loggerProxy.error("failed to get run result after interruption: " + ex.getMessage());
-        }
-        return testRun;
-    }
-
-    private void setJenkinsRunResult(final Run<?, ?> run, final String interruptionDone) {
-        if ("ABORTED".equals(interruptionDone)
-                || "STOPPED".equals(interruptionDone)
-        ) {
-            run.setResult(Result.ABORTED);
-        } else {
-            run.setResult(Result.FAILURE);
-        }
-    }
-
-    private static class RunTestCallable implements Callable<LoadTestRun, RuntimeException> {
-
+        private final transient PrintStream logger;
         private final ServerConfiguration serverConfiguration;
-        private final TaskListener listener;
-        private final String resultStr;
-        private final FilePath resultFilePath;
-
         private final TestRunOptions testRunOptions;
-        private final Map<String, String> envVarsOptions;
-        private LoadTestRun testRun = null;
-
-        private Runner runner;
-
-        private PrintStream logger() {
-            return this.listener.getLogger();
-        }
 
         RunTestCallable(
+                final PrintStream logger,
                 final ServerConfiguration serverConfiguration,
-                final TaskListener listener,
-                final String resultStr,
-                final FilePath resultFilePath,
-                final TestRunOptions testRunOptions,
-                final Map<String, String> envVarsOptions
+                final TestRunOptions testRunOptions
         ) {
+            this.logger = logger;
             this.serverConfiguration = serverConfiguration;
-            this.listener = listener;
-            this.resultStr = resultStr;
-            this.resultFilePath = resultFilePath;
             this.testRunOptions = testRunOptions;
-            this.envVarsOptions = envVarsOptions;
         }
 
         @Override
-        public LoadTestRun call() {
-            String interruptionDoneFlagName = this.testRunOptions.getTestId() + "_INTERRUPTION";
-            LoggerProxy loggerProxy = new LoggerProxy(this.logger(), new LoggerOptions(false, ""));
+        public LoadTestRun call() throws Exception {
+            LoggerProxy loggerProxy = new LoggerProxy(
+                    this.logger,
+                    new LoggerOptions(this.testRunOptions.isDebug(), "")
+            );
+
+            Runner runner = new Runner(
+                    this.serverConfiguration,
+                    this.logger,
+                    this.testRunOptions
+            );
             try {
-                EnvVars.masterEnvVars.remove(interruptionDoneFlagName);
-                this.runner = new Runner(
-                        serverConfiguration,
-                        listener.getLogger(),
-                        envVarsOptions
-                );
-                testRun = this.runner.getTestRun();
-                testRun = this.runner.run(this.testRunOptions);
-                JsonObject buildResult = new Gson().fromJson(this.resultStr, JsonObject.class);
-                buildResult.addProperty(Constants.TESTRUN, new Gson().toJson(testRun));
-
-                try {
-                    resultFilePath.write(buildResult.toString(), "UTF-8");
-//                    Utils.getSystemLogger().log(Level.INFO, "result file " + resultFilePath.getRemote());
-                } catch (Exception e) {
-                    loggerProxy.error(
-                            "Writing file [" + resultFilePath.getName() + "] failed, " + e.getMessage()
-                    );
-                }
-                return testRun;
-            } catch (InterruptedException | IOException ex) {
-                if (ex instanceof IOException && !"thread interrupted".equals(ex.getMessage())) {
-                    loggerProxy.error("error during [call]: " + ex.getMessage());
-                    if (runner != null) {
-                        return testRun;
-                    }
-                    return null;
-                }
-
-                String abortResult = Constants.UNKNOWN;
-                EnvVars.masterEnvVars.put(interruptionDoneFlagName, abortResult);
-                try {
-                    this.listener.getLogger().println("job being interrupted...");
-                    abortResult = runner.interruptHandler();
-                } catch (IOException | InterruptedException e) {
-                    loggerProxy.error("interruption handler failed.");
-                    if (e.getMessage() != null) {
-                        loggerProxy.error("interruption handler exception: " + e.getMessage());
-                    }
-                } finally {
-                    testRun = runner.getTestRun();
-                    if (testRun != null) {
-                        loggerProxy.debug("testRun: " + testRun.getId() + " ready to be written to file");
-                    } else {
-                        loggerProxy.debug("got null testRun from interruptHandler");
-                    }
-                    JsonObject buildResult = new Gson().fromJson(this.resultStr, JsonObject.class);
-                    buildResult.addProperty(Constants.TESTRUN, new Gson().toJson(testRun));
-
-                    try {
-                        resultFilePath.write(buildResult.toString(), "UTF-8");
-//                        Utils.getSystemLogger().log(Level.INFO, "result file " + resultFilePath.getRemote());
-                    } catch (Exception e) {
-                        loggerProxy.error(
-                                "Writing file [" + resultFilePath.getName() + "] failed, " + e.getMessage()
-                        );
-                    }
-                    loggerProxy.info("job interruption handler end.");
-                    loggerProxy.info(
-                            "the final status of LoadRunner Cloud test run is: " + abortResult
-                    );
-                    EnvVars.masterEnvVars.put(interruptionDoneFlagName, abortResult);
-                }
-                return testRun;
-            } catch (Exception ex) {
-                ex.printStackTrace(this.listener.getLogger());
-                return null;
+                return runner.run();
+            } catch (IOException e) {
+                loggerProxy.error("Failed to run test, " + e.getMessage());
+                throw e;
+            } catch (InterruptedException e) {
+                runner.interruptHandler();
+                throw e;
             } finally {
-                if (runner != null) {
-                    runner.close();
-                }
+                runner.close();
             }
         }
-
-        private static final long serialVersionUID = 1L;
 
         @Override
         public void checkRoles(final RoleChecker roleChecker) throws SecurityException {

--- a/src/main/java/com/microfocus/lrc/jenkins/TestRunBuilder.java
+++ b/src/main/java/com/microfocus/lrc/jenkins/TestRunBuilder.java
@@ -476,7 +476,7 @@ public final class TestRunBuilder extends Builder implements SimpleBuildStep {
         return this.testId;
     }
 
-    private LoggerProxy loggerProxy = new LoggerProxy();
+    private transient LoggerProxy loggerProxy = new LoggerProxy();
 
     @DataBoundConstructor
     public TestRunBuilder(
@@ -665,7 +665,7 @@ public final class TestRunBuilder extends Builder implements SimpleBuildStep {
         return config;
     }
 
-    private HashMap<String, Boolean> isLogPrinted;
+    private transient HashMap<String, Boolean> isLogPrinted;
 
     private void logFieldReadFromParam(
             final String fieldName,

--- a/src/main/java/com/microfocus/lrc/jenkins/TestRunPublisher.java
+++ b/src/main/java/com/microfocus/lrc/jenkins/TestRunPublisher.java
@@ -14,7 +14,6 @@ package com.microfocus.lrc.jenkins;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import com.microfocus.lrc.core.Constants;
 import com.microfocus.lrc.core.entity.*;
 import com.microfocus.lrc.core.service.Runner;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -36,7 +35,6 @@ import hudson.util.FormValidation;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.remoting.RoleChecker;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -287,25 +285,6 @@ public final class TestRunPublisher extends Recorder implements SimpleBuildStep 
             final LoadTestRun testRun,
             final TestRunBuilder.DescriptorImpl descriptor
     ) {
-        JsonObject serverConfigJSON = new JsonObject();
-
-        serverConfigJSON.addProperty("url", descriptor.getUrl());
-        serverConfigJSON.addProperty("username", descriptor.getUsername());
-        serverConfigJSON.addProperty("password", Secret.fromString(descriptor.getPassword()).getPlainText());
-        serverConfigJSON.addProperty("tenantId", descriptor.getTenantId());
-        serverConfigJSON.addProperty("projectId", testRun.getLoadTest().getProjectId());
-        serverConfigJSON.addProperty("sendEmail", opt.getSendEmail());
-        serverConfigJSON.addProperty("useOAuth", descriptor.getUseOAuth());
-        serverConfigJSON.addProperty("clientId", descriptor.getClientId());
-        if (StringUtils.isNotEmpty(descriptor.getClientSecret())) {
-            serverConfigJSON.addProperty(
-                    Constants.CLIENT_SECRET,
-                    Secret.fromString(descriptor.getClientSecret()).getPlainText()
-            );
-        } else {
-            serverConfigJSON.addProperty(Constants.CLIENT_SECRET, "");
-        }
-
         ServerConfiguration serverConfiguration;
         String usr = descriptor.getUsername();
         String pwd = Secret.fromString(descriptor.getPassword()).getPlainText();

--- a/src/main/java/com/microfocus/lrc/jenkins/TestRunReportBuildAction.java
+++ b/src/main/java/com/microfocus/lrc/jenkins/TestRunReportBuildAction.java
@@ -17,7 +17,6 @@ import com.microfocus.lrc.core.entity.TrendingConfiguration;
 import com.microfocus.lrc.core.entity.TrendingDataWrapper;
 import hudson.model.Job;
 import hudson.model.Run;
-import hudson.util.HttpResponses;
 import jenkins.model.RunAction2;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -71,10 +70,10 @@ public final class TestRunReportBuildAction implements RunAction2 {
                         : "<pre>" + new Gson().toJson(this.trendingConfig) + "</pre>";
 
         jsonStr = jsonStr + "<br>" + trendingConfigStr + "<br>" + this.trendingReportHTML;
-        HttpResponses.html(jsonStr).generateResponse(req, response, this);
+        org.kohsuke.stapler.HttpResponses.literalHtml(jsonStr).generateResponse(req, response, this);
     }
 
-    public Run getRun() {
+    public Run<?, ?> getRun() {
         return run;
     }
 
@@ -104,7 +103,7 @@ public final class TestRunReportBuildAction implements RunAction2 {
         this.trendingReportHTML = trendingReportHTML;
     }
 
-    public static TestRunReportBuildAction getLastBuildActionHasTrendingData(final Job job) {
+    public static TestRunReportBuildAction getLastBuildActionHasTrendingData(final Job<?, ?> job) {
         Run<?, ?> r = (job.getLastBuild());
         while (true) {
             if (r == null) {

--- a/src/main/java/com/microfocus/lrc/jenkins/TestRunReportProjectAction.java
+++ b/src/main/java/com/microfocus/lrc/jenkins/TestRunReportProjectAction.java
@@ -16,7 +16,6 @@ import com.microfocus.lrc.core.entity.TrendingConfiguration;
 import hudson.model.Action;
 import hudson.model.Job;
 import hudson.model.Run;
-import hudson.util.HttpResponses;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -78,12 +77,18 @@ public final class TestRunReportProjectAction implements Action {
         if (buildAction == null) {
             LoggerProxy.getSysLogger().log(
                     Level.INFO,
-                    "no valid build found for project#" + this.project.getName() + ", cannot display trending report."
+                    String.format(
+                            "no valid build found for project#%s, cannot display trending report.",
+                            this.project.getName()
+                    )
             );
         } else {
             LoggerProxy.getSysLogger().log(
                     Level.FINE,
-                    "build action found: #" + buildAction.getRun().getNumber()
+                    String.format(
+                            "build action found: #%d",
+                            buildAction.getRun().getNumber()
+                    )
             );
             if (forceUpdate || buildAction.getTrendingReportHTML() == null) {
                 htmlContent = TrendingReport.generateReport(
@@ -103,7 +108,7 @@ public final class TestRunReportProjectAction implements Action {
             htmlContent = "<h1>Failed to generate report.</h1>";
         }
 
-        HttpResponses.html(htmlContent).generateResponse(req, response, this);
+        org.kohsuke.stapler.HttpResponses.literalHtml(htmlContent).generateResponse(req, response, this);
     }
 
     public Job<?, ?> getProject() {

--- a/src/main/java/com/microfocus/lrc/jenkins/WorkflowActionFactory.java
+++ b/src/main/java/com/microfocus/lrc/jenkins/WorkflowActionFactory.java
@@ -38,18 +38,20 @@ public final class WorkflowActionFactory extends TransientActionFactory<Job> {
             try {
                 LoggerProxy.getSysLogger().log(
                         Level.FINE,
-                        "*******valid build action found*******\n"
-                                + "build#"
-                                + buildAction.getRun().getId() + "\n"
-                                + "trendingConfig "
-                                + buildAction.getTrendingConfig().toString() + "\n"
-                                + "trendingReport "
-                                + (buildAction.getTrendingReportHTML() == null
-                                ? "NULL"
-                                : buildAction.getTrendingReportHTML().length())
+                        String.format(
+                                "*******valid build action found*******\n"
+                                        + "build#%s\n"
+                                        + "trendingConfig %s\n"
+                                        + "trendingReport %s",
+                                buildAction.getRun().getId(),
+                                buildAction.getTrendingConfig().toString(),
+                                buildAction.getTrendingReportHTML() == null
+                                        ? "NULL"
+                                        : buildAction.getTrendingReportHTML().length()
+                        )
                 );
             } catch (Exception ignored) {
-
+                // ignore
             }
             return Collections.singletonList(new TestRunReportProjectAction(job, buildAction.getTrendingConfig()));
         }

--- a/src/test/java/com/microfocus/lrc/jenkins/TestRunBuilderTest.java
+++ b/src/test/java/com/microfocus/lrc/jenkins/TestRunBuilderTest.java
@@ -180,14 +180,5 @@ public class TestRunBuilderTest {
         Assert.assertTrue(workspace.child("lrc_report_FAKE_TENANT_ID--1.pdf").exists());
         Assert.assertTrue(workspace.child("lrc_report_FAKE_TENANT_ID--1.csv").exists());
         Assert.assertTrue(workspace.child("lrc_report_trans_FAKE_TENANT_ID--1.csv").exists());
-        FilePath buildResultFile = workspace.child("build_result_" + b.getId());
-
-        Assert.assertTrue(buildResultFile.exists());
-        // assert build result file contains correct data
-        String buildResult = buildResultFile.readToString();
-        JsonObject resultObj = new Gson().fromJson(buildResult, JsonObject.class);
-        LoadTestRun testRun = new Gson().fromJson(resultObj.get(Constants.TESTRUN).getAsString(), LoadTestRun.class);
-        System.out.println(resultObj);
-        Assert.assertEquals(testRun.getId(), -1);
     }
 }

--- a/src/test/java/com/microfocus/lrc/jenkins/TestRunPublisherTest.kt
+++ b/src/test/java/com/microfocus/lrc/jenkins/TestRunPublisherTest.kt
@@ -15,11 +15,8 @@ package com.microfocus.lrc.jenkins
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import com.microfocus.lrc.MockServerResponseGenerator
+import com.microfocus.lrc.core.entity.*
 import com.microfocus.lrc.core.Constants
-import com.microfocus.lrc.core.entity.LoadTest
-import com.microfocus.lrc.core.entity.LoadTestRun
-import com.microfocus.lrc.core.entity.OptionInEnvVars
-import com.microfocus.lrc.core.entity.TestRunStatus
 import hudson.EnvVars
 import hudson.Launcher
 import hudson.model.AbstractBuild
@@ -111,16 +108,17 @@ class TestRunPublisherTest {
         project.buildersList.add(object : TestBuilder() {
             override fun perform(build: AbstractBuild<*, *>, launcher: Launcher, listener: BuildListener): Boolean {
                 val buildResultObj = JsonObject();
-                buildResultObj.addProperty(Constants.TENANTID, "FAKE_TENANT_ID");
-                buildResultObj.addProperty(Constants.PROJECTID, 99);
-                buildResultObj.addProperty(Constants.SENDEMAIL, false);
+
                 val lt = LoadTest(-1, 99);
                 val testRun = LoadTestRun(-1, lt);
                 testRun.statusEnum = TestRunStatus.PASSED;
 
-                buildResultObj.addProperty(Constants.TESTRUN, Gson().toJson(testRun));
+                val opt = TestRunOptions(lt.id, false);
 
-                build.workspace!!.child("build_result_${build.id}").write(
+                buildResultObj.addProperty("testRun", Gson().toJson(testRun));
+                buildResultObj.addProperty("testOptions", Gson().toJson(opt));
+
+                build.workspace!!.child("lrc_run_result_${build.id}").write(
                     buildResultObj.toString(),
                     Charsets.UTF_8.name()
                 );


### PR DESCRIPTION
When jenkins jobs being aborted, the plugin will only request LRC server to stop current test run instead of waiting test run ending or downloading reports. 

The job will be marked as ABORTED, no matter what status the test run eventually has.